### PR TITLE
Assorted bug fixes

### DIFF
--- a/src/Drivers/WebhookDriver.php
+++ b/src/Drivers/WebhookDriver.php
@@ -54,8 +54,10 @@ class WebhookDriver extends AbstractDriver
                 $request->retry($retries, $config['retry_wait']);
             }
 
+            $data = $event->toArray();
+
             // payload?
-            if ($payload = ($config['payload'] ?? false)) {
+            if ((! in_array($config['method'], ['GET', 'DELETE'])) && ($payload = ($config['payload'] ?? $data))) {
 
                 if ($config['payload_antlers_parse'] ?? false) {
                     $payload = Antlers::parse($payload, array_merge([
@@ -70,7 +72,7 @@ class WebhookDriver extends AbstractDriver
                 $request->withBody($payload, $config['payload_content_type']);
             }
 
-            $execution->log(__('Sending request to :url', ['url' => $config['url']]));
+            $execution->log(__('Sending request to :url', ['url' => $config['url'], 'payload' => $payload]));
 
             // run the request
             $response = $request->{$config['method']}($config['url']);

--- a/src/Http/Controllers/HandlerController.php
+++ b/src/Http/Controllers/HandlerController.php
@@ -255,9 +255,10 @@ class HandlerController extends StatamicController
                     'type' => 'select',
                     'listable' => 'listable',
                     'required' => true,
-                    'taggable' => true,
+                    'taggable' => false,
                     'options' => $this->buildEventsList(),
                     'multiple' => true,
+                    'clearable' => true,
                 ],
                 'title' => [
                     'display' => __('Title'),
@@ -278,7 +279,7 @@ class HandlerController extends StatamicController
                 ],
                 'should_queue' => [
                     'display' => __('Blocking'),
-                    'handle' => 'enabled',
+                    'handle' => 'should_queue',
                     'type' => 'toggle',
                     'listable' => 'listable',
                     'default' => true,

--- a/src/Models/Execution.php
+++ b/src/Models/Execution.php
@@ -19,6 +19,8 @@ class Execution extends Model
 
     public function complete(string $output = '')
     {
+        $this->log(__('Complete'), ['output' => $output]);
+
         $this->output = $output;
         $this->status = 'completed';
         $this->save();
@@ -26,6 +28,8 @@ class Execution extends Model
 
     public function fail(string $output = '')
     {
+        $this->log(__('Failed'), ['output' => $output]);
+
         $this->output = $output;
         $this->status = 'failed';
         $this->save();

--- a/src/Traits/PreparesModels.php
+++ b/src/Traits/PreparesModels.php
@@ -51,7 +51,7 @@ trait PreparesModels
 
                 $handle = $field->handle();
 
-                if (in_array($handle, ['id', 'title', 'driver', 'events'])) {
+                if (in_array($handle, ['id', 'title', 'driver', 'events', 'should_queue', 'enabled'])) {
                     $model->setAttribute($handle, $processedValue);
 
                     return;


### PR DESCRIPTION
- [x] should_queue/enabled can't be updated and is displayed wrong in the UI.
- [x] The webhook driver is failing. Seems like it's an issues with antlers parsing and the $data variable.
- [x] Can we have a default value for payload body to basically send the full event as json?
- [x] The exception when failing is not logged.
- [x] Let's add the payload to the log for webhooks. $execution->log(__('Sending request to :url', ['url' => $config['url'], 'payload' => $payload]));