### PR TITLE
build(composer): remove pixelfear/composer-dist-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,10 @@
             "providers": [
                 "Tv2regionerne\\StatamicEvents\\ServiceProvider"
             ]
-        },
-        "download-dist": {
-            "url": "https://github.com/tv2regionerne/statamic-events/releases/download/{$version}/dist.tar.gz",
-            "path": "dist"
         }
     },
     "require": {
         "php": "^8.2",
-        "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/laravel-activitylog": "^4.7",
         "statamic/cms": "^4.46 || ^5.0"
     },
@@ -50,7 +45,6 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "allow-plugins": {
-            "pixelfear/composer-dist-plugin": true,
             "composer/package-versions-deprecated": true,
             "pestphp/pest-plugin": true
         }

--- a/src/Listeners/EventSubscriber.php
+++ b/src/Listeners/EventSubscriber.php
@@ -48,7 +48,7 @@ class EventSubscriber
 
                     if ($handler->filter) {
                         try {
-                            $result = (string)Antlers::parse($handler->filter, [
+                            $result = (string) Antlers::parse($handler->filter, [
                                 'eventName' => $eventName,
                                 'event' => collect($event)->toArray(),
                             ]);
@@ -59,7 +59,7 @@ class EventSubscriber
                                 return;
                             }
                         } catch (\Throwable $e) {
-                            $execution->fail(__('Error running filter: '. $e->getMessage()));
+                            $execution->fail(__('Error running filter: '.$e->getMessage()));
 
                             HandlerFailed::dispatch($handler, $execution, $e);
 


### PR DESCRIPTION
This pull request makes a few small changes to the `composer.json` file, primarily focused on removing the usage of the `pixelfear/composer-dist-plugin` and its related configuration.

* Removed the `pixelfear/composer-dist-plugin` from the `require` section and from the `allow-plugins` configuration. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L23-L31) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L53)
* Deleted the custom `download-dist` configuration block that was related to the plugin.